### PR TITLE
Makefile: clean also part-dependent directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
-
-DATABASE_FILES = *.csv *.db *.json *.yaml
+DATABASE_FILES = *.csv *.db *.json *.yaml *.fasm
 TIMINGS_FILES = *.sdf
+PART_DIRECTORIES = xc7*/
 
 clean-artix7-db:
 	rm -f $(addprefix artix7/,$(DATABASE_FILES))
 	rm -f $(addprefix artix7/timings/,$(TIMINGS_FILES))
+	rm -rf $(addprefix artix7/,$(PART_DIRECTORIES))
 
 clean-kintex7-db:
 	rm -f $(addprefix kintex7/,$(DATABASE_FILES))
 	rm -f $(addprefix kintex7/timings/,$(TIMINGS_FILES))
+	rm -rf $(addprefix kintex7/,$(PART_DIRECTORIES))
 
 clean-zynq7-db:
 	rm -f $(addprefix zynq7/,$(DATABASE_FILES))
 	rm -f $(addprefix zynq7/timings/,$(TIMINGS_FILES))
+	rm -rf $(addprefix zynq7/,$(PART_DIRECTORIES))
 
 clean-db: clean-artix7-db clean-kintex7-db clean-zynq7-db
 	@true


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds additional things to be cleaned:

- **Part directories** that contain part-dependent generated files: tilegrid, tileconn, etc.
- **`*.fasm`** files: e.g. `xc7z010clg400-1_required_features.fasm`